### PR TITLE
feat: set token cookie server side

### DIFF
--- a/composables/useFirebaseAuth.ts
+++ b/composables/useFirebaseAuth.ts
@@ -5,9 +5,6 @@ import {
   signInWithEmailAndPassword,
 } from 'firebase/auth'
 
-// 60sec * 60min * 24h = 1 day in seconds
-const dayInSeconds = 60 * 60 * 24
-
 export const registerUser = async (email: string, password: string) => {
   const auth = getAuth()
   const credentials = await createUserWithEmailAndPassword(
@@ -36,7 +33,19 @@ export const signinUser = async (email: string, password: string) => {
 
 export const signoutUser = async () => {
   const auth = getAuth()
+  const authStore = useAuthStore()
+
   await auth.signOut()
+
+  // remove token cookie
+  try {
+    await $fetch('/api/user/signout', {
+      method: 'POST',
+    })
+  } catch (error) {
+    console.log('Could not sign out user')
+  }
+  authStore.user = null
 }
 
 export const initUser = () => {
@@ -44,19 +53,24 @@ export const initUser = () => {
 
   onAuthStateChanged(auth, async (user) => {
     const authStore = useAuthStore()
-    const token = useCookie('token', {
-      maxAge: dayInSeconds * 1, // 24 hours
-    })
 
     if (user) {
       // store idToken in cookie for use on server
-      token.value = await user.getIdToken()
+      const idToken = await user.getIdToken()
 
       // fetch user data if user is not already signed in after server render
-      if (!authStore.isLoggedIn) authStore.user = await $fetch('/api/user')
+      if (!authStore.isLoggedIn)
+        try {
+          authStore.user = await $fetch('/api/user', {
+            headers: {
+              Authorization: `Bearer ${idToken}`,
+            },
+          })
+        } catch (error) {
+          console.error('Could not fetch user data')
+        }
     } else {
       authStore.user = null
-      token.value = null
     }
   })
 }

--- a/server/api/user/signout.post.ts
+++ b/server/api/user/signout.post.ts
@@ -1,0 +1,18 @@
+// POST /api/user/signout
+// endpoint for removing the token cookie after the user signs out
+
+export default defineEventHandler((event) => {
+  const { user } = event.context
+
+  // user is not authenticated
+  if (!user)
+    throw createError({
+      statusCode: 401,
+      statusMessage: 'Not signed in',
+    })
+
+  deleteCookie(event, '_token')
+
+  // send response to remove cookie
+  sendNoContent(event, 204)
+})

--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -1,8 +1,21 @@
-export default defineEventHandler(async (event) => {
-  // get idToken from cookie
-  const idToken = getCookie(event, 'token')
+// 60sec * 60min * 24h = 1 day in seconds
+const dayInSeconds = 60 * 60 * 24
 
+export default defineEventHandler(async (event) => {
+  // get idToken from Authorization header or cookie
+  let idToken = getHeader(event, 'Authorization') ?? getCookie(event, '_token')
+  console.log(idToken)
+  // no idToken
   if (!idToken) return
+
+  // set new token cookie on response
+  if (idToken.includes('Bearer')) {
+    idToken = idToken.split('Bearer ')[1]
+    setCookie(event, '_token', idToken, {
+      httpOnly: true,
+      maxAge: dayInSeconds * 1,
+    })
+  }
 
   try {
     // check validity of idToken


### PR DESCRIPTION
Some pretty important changes here security wise 🙏 

# Changes
- When signing in send the _idToken_ to the server on the _ Authorization _ header. The auth middleware uses a _set-cookie_ to set the __token_ cookie as an `http-only` cookie. This makes the system less vulnerable to attacks, as the cookie cannot be accessed with client side javascript.
- Add `POST /api/user/signout` to remove the cookie when signing out.