### PR TITLE
feat: company api endpoints

### DIFF
--- a/components/nav/Button.vue
+++ b/components/nav/Button.vue
@@ -1,20 +1,3 @@
-<template>
-  <NuxtLink :to="localePath(route.route)" @click="app.drawer = false">
-    <VBtn
-      color="black"
-      variant="text"
-      :rounded="!route.icon ? 'lg' : undefined"
-      :width="!route.icon ? '100%' : undefined"
-      :active="active && ($route.name as string).includes(route.name)"
-      :icon="route.icon"
-    >
-      <template v-if="!route.icon" #default>
-        {{ $t(`nav.${route.name}`) }}
-      </template>
-    </VBtn>
-  </NuxtLink>
-</template>
-
 <script setup lang="ts">
   import type { Route } from '@/models/Nav'
 
@@ -32,3 +15,20 @@
     },
   })
 </script>
+
+<template>
+  <NuxtLink :to="localePath(route.route)" @click="app.drawer = false">
+    <VBtn
+      color="black"
+      variant="text"
+      :rounded="!route.icon ? 'lg' : undefined"
+      :width="!route.icon ? '100%' : undefined"
+      :active="active && ($route.name as string).includes(route.name)"
+      :icon="route.icon"
+    >
+      <template v-if="!route.icon" #default>
+        {{ $t(`nav.${route.name}`) }}
+      </template>
+    </VBtn>
+  </NuxtLink>
+</template>

--- a/components/nav/Buttons.vue
+++ b/components/nav/Buttons.vue
@@ -1,14 +1,3 @@
-<template>
-  <div :class="`d-flex ${flexDirection} justify-end`">
-    <NavButton
-      v-for="(route, index) in routes"
-      :key="index"
-      :route="route"
-      :class="direction === 'horizontal' ? 'ma-2' : 'my-2'"
-    />
-  </div>
-</template>
-
 <script setup lang="ts">
   import type { Route } from '@/models/Nav'
 
@@ -33,3 +22,14 @@
     }
   })
 </script>
+
+<template>
+  <div :class="`d-flex ${flexDirection} justify-end`">
+    <NavButton
+      v-for="(route, index) in routes"
+      :key="index"
+      :route="route"
+      :class="direction === 'horizontal' ? 'ma-2' : 'my-2'"
+    />
+  </div>
+</template>

--- a/components/nav/Horizontal.vue
+++ b/components/nav/Horizontal.vue
@@ -1,3 +1,19 @@
+<script setup lang="ts">
+  import type { Route } from '@/models/Nav'
+
+  const localePath = useLocalePath()
+  const { mobile } = useDisplay()
+
+  const auth = useAuthStore()
+  const app = useAppStore()
+
+  type Routes = Route[]
+
+  defineProps({
+    routes: { type: Array as PropType<Routes>, required: true },
+  })
+</script>
+
 <template>
   <VAppBar
     scroll-behavior="hide"
@@ -49,22 +65,6 @@
     </template>
   </VAppBar>
 </template>
-
-<script setup lang="ts">
-  import type { Route } from '@/models/Nav'
-
-  const localePath = useLocalePath()
-  const { mobile } = useDisplay()
-
-  const auth = useAuthStore()
-  const app = useAppStore()
-
-  type Routes = Route[]
-
-  defineProps({
-    routes: { type: Array as PropType<Routes>, required: true },
-  })
-</script>
 
 <style scoped lang="scss">
   @use 'vuetify/settings';

--- a/components/nav/Vertical.vue
+++ b/components/nav/Vertical.vue
@@ -1,3 +1,18 @@
+<script setup lang="ts">
+  import type { Route } from '@/models/Nav'
+
+  const auth = useAuthStore()
+  const app = useAppStore()
+
+  const { xs, width } = useDisplay()
+
+  type Routes = Route[]
+
+  defineProps({
+    routes: { type: Array as PropType<Routes>, required: true },
+  })
+</script>
+
 <template>
   <VNavigationDrawer
     location="right"
@@ -58,18 +73,3 @@
     </template>
   </VNavigationDrawer>
 </template>
-
-<script setup lang="ts">
-  import type { Route } from '@/models/Nav'
-
-  const auth = useAuthStore()
-  const app = useAppStore()
-
-  const { xs, width } = useDisplay()
-
-  type Routes = Route[]
-
-  defineProps({
-    routes: { type: Array as PropType<Routes>, required: true },
-  })
-</script>

--- a/components/user/StateButton.vue
+++ b/components/user/StateButton.vue
@@ -1,3 +1,8 @@
+<script setup lang="ts">
+  const auth = useAuthStore()
+  const localePath = useLocalePath()
+</script>
+
 <template>
   <VBtn
     rounded="lg"
@@ -10,8 +15,3 @@
     {{ auth.isLoggedIn ? $t('user.sign_out') : $t('user.sign_in') }}
   </VBtn>
 </template>
-
-<script setup lang="ts">
-  const auth = useAuthStore()
-  const localePath = useLocalePath()
-</script>

--- a/error.vue
+++ b/error.vue
@@ -1,16 +1,3 @@
-<template>
-  <div class="d-flex h-screen justify-center">
-    <VSheet class="text-center mt-10">
-      <h1 class="text-orange text-h1 font-weight-bold pb-3">Oh no!</h1>
-      <h4 class="text-h4 pb-1">Error {{ props.error.statusCode }}</h4>
-      <h5 class="text-h5 pb-2 break-text">
-        {{ props.error.message }}
-      </h5>
-      <VBtn @click="handleError">Return to frontpage</VBtn>
-    </VSheet>
-  </div>
-</template>
-
 <script setup lang="ts">
   const props = defineProps({
     error: Object(),
@@ -23,6 +10,19 @@
       redirect: localePath('/'),
     })
 </script>
+
+<template>
+  <div class="d-flex h-screen justify-center">
+    <VSheet class="text-center mt-10">
+      <h1 class="text-orange text-h1 font-weight-bold pb-3">Oh no!</h1>
+      <h4 class="text-h4 pb-1">Error {{ props.error.statusCode }}</h4>
+      <h5 class="text-h5 pb-2 break-text">
+        {{ props.error.message }}
+      </h5>
+      <VBtn @click="handleError">Return to frontpage</VBtn>
+    </VSheet>
+  </div>
+</template>
 
 <style scoped>
   .break-text {

--- a/models/User.ts
+++ b/models/User.ts
@@ -6,6 +6,7 @@ export interface TokenData {
 
 export interface User extends TokenData {
   userType: 'company' | 'admin'
-  studyProgram: string
+  studyProgram?: string
+  companyUID?: string
   updated: number
 }

--- a/pages/[...slug].vue
+++ b/pages/[...slug].vue
@@ -1,3 +1,7 @@
+<script setup lang="ts">
+  const localePath = useLocalePath()
+</script>
+
 <template>
   <div class="d-flex h-screen mt-10 justify-center">
     <VSheet class="text-center">
@@ -9,10 +13,6 @@
     </VSheet>
   </div>
 </template>
-
-<script setup lang="ts">
-  const localePath = useLocalePath()
-</script>
 
 <style scoped>
   .break-text {

--- a/pages/admin.vue
+++ b/pages/admin.vue
@@ -1,9 +1,3 @@
-<template>
-  <div>
-    <NuxtPage />
-  </div>
-</template>
-
 <script setup lang="ts">
   definePageMeta({
     // route and all sub routes are protected
@@ -21,3 +15,9 @@
     },
   })
 </script>
+
+<template>
+  <div>
+    <NuxtPage />
+  </div>
+</template>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -8,45 +8,5 @@
         title: 'Elektronikk & Teknologidagen',
       }"
     />
-
-    <VBtn color="success" @click="createCompany">createCompany</VBtn>
-    <VBtn color="success" @click="udpateCompany">udpateCompany</VBtn>
-    <VBtn color="error" @click="deleteCompany">deleteCompany</VBtn>
-
-    {{ companies }}
   </div>
 </template>
-
-<script setup lang="ts">
-  const { data: companies } = await useFetch(`/api/company`)
-
-  const createCompany = async () => {
-    await $fetch('/api/company', {
-      method: 'POST',
-      body: {
-        name: 'Company of Things',
-        webpage: 'cot.no',
-        type: 'partner',
-      },
-    })
-  }
-
-  const udpateCompany = async () => {
-    await $fetch('/api/company', {
-      method: 'PUT',
-      body: {
-        name: 'Company of Things',
-        companyUID: '-NehfYyZOHF6-6aYVcx8',
-      },
-    })
-  }
-
-  const deleteCompany = async () => {
-    await $fetch('/api/company', {
-      method: 'DELETE',
-      body: {
-        companyUID: '-NehfYyZOHF6-6aYVcx8',
-      },
-    })
-  }
-</script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -14,10 +14,48 @@
       "
       >Create user</VBtn
     >
+
+    <VBtn color="success" @click="createCompany">createCompany</VBtn>
+    <VBtn color="success" @click="udpateCompany">udpateCompany</VBtn>
+    <VBtn color="error" @click="deleteCompany">deleteCompany</VBtn>
+
+    {{ companies }}
   </div>
 </template>
 
 <script setup lang="ts">
   const authStore = useAuthStore()
   const { user } = storeToRefs(authStore)
+
+  const { data: companies } = await useFetch(`/api/company`)
+
+  const createCompany = async () => {
+    await $fetch('/api/company', {
+      method: 'POST',
+      body: {
+        name: 'Company of Things',
+        webpage: 'cot.no',
+        type: 'partner',
+      },
+    })
+  }
+
+  const udpateCompany = async () => {
+    await $fetch('/api/company', {
+      method: 'PUT',
+      body: {
+        name: 'Company of Things',
+        companyUID: '-NehfYyZOHF6-6aYVcx8',
+      },
+    })
+  }
+
+  const deleteCompany = async () => {
+    await $fetch('/api/company', {
+      method: 'DELETE',
+      body: {
+        companyUID: '-NehfYyZOHF6-6aYVcx8',
+      },
+    })
+  }
 </script>

--- a/pages/user/index.vue
+++ b/pages/user/index.vue
@@ -1,7 +1,3 @@
-<template>
-  <div>Welcome {{ user?.name }}!</div>
-</template>
-
 <script setup lang="ts">
   definePageMeta({
     // route is protected
@@ -11,3 +7,7 @@
   const authStore = useAuthStore()
   const { user } = storeToRefs(authStore)
 </script>
+
+<template>
+  <div>Welcome {{ user?.name }}!</div>
+</template>

--- a/pages/user/signin.vue
+++ b/pages/user/signin.vue
@@ -1,3 +1,11 @@
+<script setup lang="ts">
+  const signIn = async () => {
+    // test user credentials
+    // await signinUser('aasmund@cot.as', 'abc123+A')
+    await signinUser('petter@cot.as', '123456')
+  }
+</script>
+
 <template>
   <div>
     Login page
@@ -11,11 +19,3 @@
     </p>
   </div>
 </template>
-
-<script setup lang="ts">
-  const signIn = async () => {
-    // test user credentials
-    // await signinUser('aasmund@cot.as', 'abc123+A')
-    await signinUser('petter@cot.as', '123456')
-  }
-</script>

--- a/server/api/company/index.delete.ts
+++ b/server/api/company/index.delete.ts
@@ -15,10 +15,10 @@ export default defineEventHandler(async (event) => {
   const { companyUID } = await readBody(event)
 
   // reference to companies
-  const companiesRed = db.ref('companies')
+  const companiesRef = db.ref('companies')
 
   // remove company
-  companiesRed.child(companyUID).remove()
+  companiesRef.child(companyUID).remove()
 
   // company successfully removed
   sendNoContent(event, 204)

--- a/server/api/company/index.delete.ts
+++ b/server/api/company/index.delete.ts
@@ -1,0 +1,25 @@
+// DELETE /api/company
+// endpoint for removing a company from db
+
+export default defineEventHandler(async (event) => {
+  const { user } = event.context
+
+  // only admins can remove companies
+  if (!hasAccess(user, ['admin']))
+    throw createError({
+      statusCode: 401,
+      statusMessage: 'User not authorized',
+    })
+
+  // get request body
+  const { companyUID } = await readBody(event)
+
+  // reference to companies
+  const companiesRed = db.ref('companies')
+
+  // remove company
+  companiesRed.child(companyUID).remove()
+
+  // company successfully removed
+  sendNoContent(event, 204)
+})

--- a/server/api/company/index.post.ts
+++ b/server/api/company/index.post.ts
@@ -22,7 +22,7 @@ export default defineEventHandler(async (event) => {
       statusMessage: 'Missing company name, webpage, or type',
     })
 
-  companiesRef.push().set({
+  companiesRef.push({
     description: description ?? null,
     logo: logo ?? null,
     name,

--- a/server/api/company/index.post.ts
+++ b/server/api/company/index.post.ts
@@ -1,0 +1,35 @@
+// POST /api/company
+// endpoint for creating companies in the db
+
+export default defineEventHandler(async (event) => {
+  const { user } = event.context
+
+  // only admins can create new companies
+  if (!hasAccess(user, ['admin']))
+    throw createError({
+      statusCode: 401,
+      statusMessage: 'User not authorized',
+    })
+
+  const { description, logo, name, type, webpage } = await readBody(event)
+
+  const companiesRef = db.ref('companies')
+
+  // description and logo are not required, but should be set by a company admin
+  if (!name || !webpage || !type)
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Missing company name, webpage, or type',
+    })
+
+  companiesRef.push().set({
+    description: description ?? null,
+    logo: logo ?? null,
+    name,
+    type,
+    webpage,
+  })
+
+  // successfully created company
+  sendNoContent(event, 201)
+})

--- a/server/api/company/index.put.ts
+++ b/server/api/company/index.put.ts
@@ -5,7 +5,7 @@ export default defineEventHandler(async (event) => {
   const { user } = event.context
 
   // get request body
-  const { companyUID, ...updatedData } = await readBody(event)
+  const { companyUID, ...newData } = await readBody(event)
 
   const isAdmin = hasAccess(user, ['admin'])
   const isCompanyAdmin =
@@ -37,11 +37,11 @@ export default defineEventHandler(async (event) => {
     })
 
   // only admins can change company types
-  if (!isAdmin) updatedData.type = data[companyUID].type
+  if (!isAdmin) delete newData.type
 
   // update company data
-  companiesRef.child(companyUID).update(updatedData)
+  companiesRef.child(companyUID).update(newData)
 
   // successfully modified companies
-  sendNoContent(event, 201)
+  sendNoContent(event, 204)
 })

--- a/server/api/company/index.put.ts
+++ b/server/api/company/index.put.ts
@@ -1,0 +1,47 @@
+// PUT /api/company
+// endpoint for modifying companies in the db
+
+export default defineEventHandler(async (event) => {
+  const { user } = event.context
+
+  // get request body
+  const { companyUID, ...updatedData } = await readBody(event)
+
+  const isAdmin = hasAccess(user, ['admin'])
+  const isCompanyAdmin =
+    hasAccess(user, ['company']) && user.companyUID === companyUID
+
+  // only admins and company admins can modify companies
+  if (!isAdmin && !isCompanyAdmin)
+    throw createError({
+      statusCode: 401,
+      statusMessage: 'User not authorized',
+    })
+
+  // reference to companies
+  const companiesRef = db.ref('companies')
+
+  // check if the company exists
+  const snapshot = await companiesRef
+    .orderByKey()
+    .equalTo(companyUID)
+    .once('value')
+
+  const data = snapshot.val()
+
+  // the company does not exist in db
+  if (!data)
+    throw createError({
+      statusCode: 404,
+      statusMessage: 'Company not found',
+    })
+
+  // only admins can change company types
+  if (!isAdmin) updatedData.type = data[companyUID].type
+
+  // update company data
+  companiesRef.child(companyUID).update(updatedData)
+
+  // successfully modified companies
+  sendNoContent(event, 201)
+})

--- a/server/api/company/index.ts
+++ b/server/api/company/index.ts
@@ -1,0 +1,26 @@
+// GET /api/company
+// endpoint for fetching companies from db
+
+export default defineEventHandler(async (event) => {
+  const { companyUID } = getQuery(event)
+
+  const companiesRef = db.ref('companies')
+
+  // return all companies if no company is specified
+  if (!companyUID) {
+    const snapshot = await companiesRef.orderByKey().once('value')
+    const data = snapshot.val()
+
+    return data
+  }
+
+  // get specified company
+  const snapshot = await companiesRef
+    .orderByKey()
+    .equalTo(companyUID as string)
+    .once('value')
+
+  const data = snapshot.val()
+
+  return data
+})


### PR DESCRIPTION
Adds Nuxt server routes to modify companies in the database.

# Changes

- `GET /api/company` returns all companies from the database. If the query parameter `companyUID` is set it will return only the specified company.
- `POST /api/company` is only accessible by administrators and creates a new company in the database. It accepts a body of the format:
```ts
{
   description?: string
   logo?: string
   name: string
   type: 'partner' | 'sponsor' | 'mainPartner'
   webpage: string
}
```
- `PUT /api/company` updates a specified company in the database. The endpoint is accessible by administrators and company administrators (that is a user with type _company_ and with _companyUID_ set to the company that is to be modified). The endpoint accepts the same body as `POST /api/company` with one addition; the `companyUID` key specifies which company to modify.
- `DELETE /api/company` is only accessible by administrators and deletes a company from the database. The `companyUID` key of the request body specified which company to delete.
- Move all script tags to top of component files.