### PR TITLE
feat: company user creation

### DIFF
--- a/composables/useFirebaseAuth.ts
+++ b/composables/useFirebaseAuth.ts
@@ -6,6 +6,8 @@ import {
   updateProfile,
 } from 'firebase/auth'
 
+import type { User } from '@/models/User'
+
 type newUser = {
   email: string
   password: string
@@ -145,7 +147,7 @@ export const initUser = () => {
     const idToken = await user.getIdToken()
 
     try {
-      authStore.user = await $fetch('/api/user', {
+      authStore.user = await $fetch<User>('/api/user', {
         headers: {
           Authorization: `Bearer ${idToken}`,
         },

--- a/composables/useFirebaseAuth.ts
+++ b/composables/useFirebaseAuth.ts
@@ -12,7 +12,7 @@ type newUser = {
   email: string
   password: string
   studyProgram?: string
-  currentYear?: string
+  currentYear?: number
   name: string
 }
 

--- a/composables/useFirebaseAuth.ts
+++ b/composables/useFirebaseAuth.ts
@@ -12,6 +12,7 @@ type newUser = {
   email: string
   password: string
   studyProgram?: string
+  currentYear?: string
   name: string
 }
 
@@ -20,11 +21,11 @@ export const registerUser = async (
   newUser: newUser,
   registrationCode?: string
 ) => {
-  // studyprogram is required when not creating a company user
-  if (!registrationCode && !newUser.studyProgram)
+  // studyprogram and current year are required when not creating a company user
+  if (!registrationCode && (!newUser.studyProgram || !newUser.currentYear))
     throw createError({
       statusCode: 400,
-      statusMessage: 'Missing studyprogram',
+      statusMessage: 'Missing studyprogram or current year',
     })
 
   // name is handled client side with the firebase SDK and is required
@@ -73,6 +74,7 @@ export const registerUser = async (
     },
     body: {
       studyProgram: newUser.studyProgram,
+      currentYear: newUser.currentYear,
     },
     query: {
       code: registrationCode,

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,29 +1,3 @@
-<script setup lang="ts">
-  const createCode = async () => {
-    await $fetch('/api/code', {
-      method: 'POST',
-      query: {
-        companyUID: '-NesGFDmavw-y88kvfYM',
-      },
-    })
-  }
-
-  const code = 'company-of-things-utcUHFsp'
-
-  const checkCode = async () => {
-    await $fetch(`/api/code/${code}`)
-  }
-
-  const deleteCode = async () => {
-    await $fetch(`/api/code`, {
-      method: 'DELETE',
-      body: {
-        code,
-      },
-    })
-  }
-</script>
-
 <template>
   <div>
     <HomeBanner
@@ -34,9 +8,5 @@
         title: 'Elektronikk & Teknologidagen',
       }"
     />
-
-    <VBtn color="success" @click="createCode">Create Code</VBtn>
-    <VBtn color="success" @click="checkCode">Check Code</VBtn>
-    <VBtn color="error" @click="deleteCode">Delete Code</VBtn>
   </div>
 </template>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,3 +1,29 @@
+<script setup lang="ts">
+  const createCode = async () => {
+    await $fetch('/api/code', {
+      method: 'POST',
+      query: {
+        companyUID: '-NesGFDmavw-y88kvfYM',
+      },
+    })
+  }
+
+  const code = 'company-of-things-utcUHFsp'
+
+  const checkCode = async () => {
+    await $fetch(`/api/code/${code}`)
+  }
+
+  const deleteCode = async () => {
+    await $fetch(`/api/code`, {
+      method: 'DELETE',
+      body: {
+        code,
+      },
+    })
+  }
+</script>
+
 <template>
   <div>
     <HomeBanner
@@ -8,5 +34,9 @@
         title: 'Elektronikk & Teknologidagen',
       }"
     />
+
+    <VBtn color="success" @click="createCode">Create Code</VBtn>
+    <VBtn color="success" @click="checkCode">Check Code</VBtn>
+    <VBtn color="error" @click="deleteCode">Delete Code</VBtn>
   </div>
 </template>

--- a/pages/user/signin.vue
+++ b/pages/user/signin.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
   const signIn = async () => {
     // test user credentials
-    // await signinUser('aasmund@cot.as', 'abc123+A')
-    await signinUser('petter@cot.as', '123456')
+    // await signinUser('basic@test.no', 'password')
+    // await signinUser('company@test.no', 'password')
+    await signinUser('admin@test.no', 'password')
   }
 </script>
 

--- a/server/api/code/[code].ts
+++ b/server/api/code/[code].ts
@@ -4,8 +4,10 @@
 export default defineEventHandler(async (event) => {
   const code = getRouterParam(event, 'code') as string
 
+  // reference to registration codes in db
   const registrationCodes = db.ref('registrationCodes')
 
+  // fetch code from db
   const snapshot = await registrationCodes
     .orderByChild('value')
     .equalTo(code)

--- a/server/api/code/[code].ts
+++ b/server/api/code/[code].ts
@@ -3,20 +3,9 @@
 
 export default defineEventHandler(async (event) => {
   const code = getRouterParam(event, 'code') as string
+  const { isValid } = await validateCode(code)
 
-  // reference to registration codes in db
-  const registrationCodes = db.ref('registrationCodes')
-
-  // fetch code from db
-  const snapshot = await registrationCodes
-    .orderByChild('value')
-    .equalTo(code)
-    .once('value')
-
-  const data = snapshot.val()
-
-  // if code exists return true
   return {
-    idValid: !!data,
+    isValid,
   }
 })

--- a/server/api/code/[code].ts
+++ b/server/api/code/[code].ts
@@ -1,0 +1,20 @@
+// GET /api/code/:code
+// endpoint for checking if a registration code is valid
+
+export default defineEventHandler(async (event) => {
+  const code = getRouterParam(event, 'code') as string
+
+  const registrationCodes = db.ref('registrationCodes')
+
+  const snapshot = await registrationCodes
+    .orderByChild('value')
+    .equalTo(code)
+    .once('value')
+
+  const data = snapshot.val()
+
+  // if code exists return true
+  return {
+    idValid: !!data,
+  }
+})

--- a/server/api/code/index.delete.ts
+++ b/server/api/code/index.delete.ts
@@ -1,4 +1,4 @@
-// DELETE /api/company
+// DELETE /api/code
 // endpoint for removing a registration code from db
 
 export default defineEventHandler(async (event) => {

--- a/server/api/code/index.delete.ts
+++ b/server/api/code/index.delete.ts
@@ -15,7 +15,7 @@ export default defineEventHandler(async (event) => {
   const { code } = await readBody(event)
 
   // delete code
-  deleteCode(code)
+  await deleteCode(code)
 
   // company successfully removed
   sendNoContent(event, 204)

--- a/server/api/code/index.delete.ts
+++ b/server/api/code/index.delete.ts
@@ -1,0 +1,22 @@
+// DELETE /api/company
+// endpoint for removing a registration code from db
+
+export default defineEventHandler(async (event) => {
+  const { user } = event.context
+
+  // only admins can remove registration codes
+  if (!hasAccess(user, ['admin']))
+    throw createError({
+      statusCode: 401,
+      statusMessage: 'User not authorized',
+    })
+
+  // get request body
+  const { code } = await readBody(event)
+
+  // delete code
+  deleteCode(code)
+
+  // company successfully removed
+  sendNoContent(event, 204)
+})

--- a/server/api/code/index.post.ts
+++ b/server/api/code/index.post.ts
@@ -49,7 +49,7 @@ export default defineEventHandler(async (event) => {
 
   // create code in db
   registrationCodesRef.push({
-    value: `${kebabCaseName}-${randomString}`,
+    code: `${kebabCaseName}-${randomString}`,
     companyUID,
   })
 

--- a/server/api/code/index.post.ts
+++ b/server/api/code/index.post.ts
@@ -1,0 +1,60 @@
+// POST /api/code
+// endpoint for creating registration codes in the db
+
+import { generateRandomString } from '../../utils/randomString'
+
+export default defineEventHandler(async (event) => {
+  const { user } = event.context
+
+  // only admins can create new registration codes
+  if (!hasAccess(user, ['admin']))
+    throw createError({
+      statusCode: 401,
+      statusMessage: 'User not authorized',
+    })
+
+  const { companyUID } = getQuery(event)
+
+  // companyUID is missing
+  if (!companyUID)
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Missing companyUID',
+    })
+
+  // reference to companies
+  const companiesRef = db.ref('companies')
+
+  // check if the company exists
+  const snapshot = await companiesRef
+    .orderByKey()
+    .equalTo(companyUID as string)
+    .once('value')
+
+  const data = snapshot.val()
+
+  // the company does not exist in db
+  if (!data)
+    throw createError({
+      statusCode: 404,
+      statusMessage: 'Company not found',
+    })
+
+  // reference to registration codes in db
+  const registrationCodesRef = db.ref('registrationCodes')
+
+  // create values for code
+  const kebabCaseName = data[companyUID as string].name
+    .replace(/\s+/g, '-')
+    .toLowerCase()
+  const randomString = generateRandomString(8)
+
+  // create code in db
+  registrationCodesRef.push({
+    value: `${kebabCaseName}-${randomString}`,
+    companyUID,
+  })
+
+  // successfully created registration code
+  sendNoContent(event, 201)
+})

--- a/server/api/code/index.post.ts
+++ b/server/api/code/index.post.ts
@@ -1,8 +1,6 @@
 // POST /api/code
 // endpoint for creating registration codes in the db
 
-import { generateRandomString } from '../../utils/randomString'
-
 export default defineEventHandler(async (event) => {
   const { user } = event.context
 

--- a/server/api/user/index.post.ts
+++ b/server/api/user/index.post.ts
@@ -32,7 +32,7 @@ export default defineEventHandler(async (event) => {
   // only admins can modify usertypes and other users than their own
   if (!hasAccess(user, ['admin']) || !uid) {
     // prevent users from creating multiple instances in the db
-    uid = user.uid ?? decodedToken.uid
+    uid = user?.uid ?? decodedToken.uid
     userType = user?.userType
     companyUID = user?.companyUID
   }

--- a/server/utils/deleteCode.ts
+++ b/server/utils/deleteCode.ts
@@ -1,13 +1,27 @@
 // utility function for deleting a registration code
 // used when registering a company user or calling DELETE /api/code
 
-export const deleteCode = (code: string) => {
+export const deleteCode = async (code: string) => {
   // reference to registration codes
   const registrationCodesRef = db.ref('registrationCodes')
 
   // get reference to code
-  const codeRef = registrationCodesRef.orderByChild('value').equalTo(code).ref
+  const snapshot = await registrationCodesRef
+    .orderByChild('code')
+    .equalTo(code)
+    .once('value')
 
-  // remove code
-  codeRef.remove()
+  // get parent key of code
+  const data = snapshot.val()
+
+  if (!data)
+    throw createError({
+      statusCode: 404,
+      statusMessage: 'Code does not exist',
+    })
+
+  const key = Object.keys(data)[0]
+
+  // remove registration code
+  await registrationCodesRef.child(key).remove()
 }

--- a/server/utils/deleteCode.ts
+++ b/server/utils/deleteCode.ts
@@ -11,7 +11,6 @@ export const deleteCode = async (code: string) => {
     .equalTo(code)
     .once('value')
 
-  // get parent key of code
   const data = snapshot.val()
 
   if (!data)
@@ -20,6 +19,7 @@ export const deleteCode = async (code: string) => {
       statusMessage: 'Code does not exist',
     })
 
+  // get parent key of code
   const key = Object.keys(data)[0]
 
   // remove registration code

--- a/server/utils/deleteCode.ts
+++ b/server/utils/deleteCode.ts
@@ -1,0 +1,13 @@
+// utility function for deleting a registration code
+// used when registering a company user or calling DELETE /api/code
+
+export const deleteCode = (code: string) => {
+  // reference to companies
+  const registrationCodesRef = db.ref('registrationCodes')
+
+  // get reference to code
+  const codeRef = registrationCodesRef.orderByChild('value').equalTo(code).ref
+
+  // remove code
+  codeRef.remove()
+}

--- a/server/utils/deleteCode.ts
+++ b/server/utils/deleteCode.ts
@@ -2,7 +2,7 @@
 // used when registering a company user or calling DELETE /api/code
 
 export const deleteCode = (code: string) => {
-  // reference to companies
+  // reference to registration codes
   const registrationCodesRef = db.ref('registrationCodes')
 
   // get reference to code

--- a/server/utils/randomString.ts
+++ b/server/utils/randomString.ts
@@ -1,0 +1,15 @@
+// utility function for generating a random string with
+// a specified length, used to generate registration codes
+
+export const generateRandomString = (length: number) => {
+  let result = ''
+  const characters =
+    'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstauvwxyz0123456789'
+
+  const charactersLength = characters.length
+
+  for (let i = 0; i < length; i++)
+    result += characters.charAt(Math.floor(Math.random() * charactersLength))
+
+  return result
+}

--- a/server/utils/validateCode.ts
+++ b/server/utils/validateCode.ts
@@ -8,11 +8,12 @@ export const validateCode = async (code: string) => {
     .equalTo(code)
     .once('value')
 
+  // get code data and companyUID
   const data = snapshot.val()
+  const companyUID = data ? data[Object.keys(data)[0]].companyUID : null
 
-  // if code exists return true
   return {
     isValid: !!data,
-    companyUID: data?.companyUID,
+    companyUID,
   }
 }

--- a/server/utils/validateCode.ts
+++ b/server/utils/validateCode.ts
@@ -1,0 +1,18 @@
+export const validateCode = async (code: string) => {
+  // reference to registration codes in db
+  const registrationCodes = db.ref('registrationCodes')
+
+  // fetch code from db
+  const snapshot = await registrationCodes
+    .orderByChild('code')
+    .equalTo(code)
+    .once('value')
+
+  const data = snapshot.val()
+
+  // if code exists return true
+  return {
+    isValid: !!data,
+    companyUID: data?.companyUID,
+  }
+}


### PR DESCRIPTION
# Changes
- `POST /api/code` is only accessible by administrators and creates a new registration code in the database. The endpoint accepts a body with the key `companyUID`. A registration code is connected to a company and has the following format in the database.
```ts
{
   companyUID: string
   code: string
}
```
- `GET /api/code/:code` validates the code passed as a route parameter. The result body has the following format.
```ts
{
   isValid: boolean
}
```
- `DELETE /api/code` is only accessible by administrators and deletes the code passed through the key `code` in the request body.
- Server utility function `deleteCode` to delete registration codes.
- Server utility function `randomString` to generate a random string with a specified length.
- Updated user endpoints and composables to allow creation of company users, utilising the registration code endpoints. 

# Creating users

The server endpoint for creating users has become quite complex. It can be used both for creating new user and modifying existing users in the database. At some point I will write an extensive guide on how to use the endpoint in the wiki. For now the most important thing is how to create new users.

```ts
// create basic user
registerUser({
   email: 'basic@test.no',
   name: 'Basic User',
   password: 'password',
   studyProgram: 'elsus',
   currentYear: 3,
})

// create company user using the code stored in registrationCode
registerUser({
   email: 'company@test.no',
   name: 'Company User',
   password: 'password',
}, registrationCode)
```

When calling the `registerUser` function  remember to handle errors properly with _trycatch_ blocks. I have created three test users all with the same password `password`: basic@test.no, company@test.no, and admin@test.no.