### PR TITLE
feat: create job api endpoints

### DIFF
--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -1,7 +1,7 @@
 {
   "nav": {
     "index": "Home",
-    "program": "Program",
+    "program": "Programme",
     "jobs": "Jobs",
     "contact": "Contact",
     "admin": "Administration",

--- a/server/api/event/index.post.ts
+++ b/server/api/event/index.post.ts
@@ -15,19 +15,6 @@ export default defineEventHandler(async (event) => {
     eventType,
   } = await readBody(event)
 
-  // Check if user is authorized
-  if (hasAccess(user, ['company'])) {
-    if (user.companyUID !== companyUID)
-      throw createError({
-        statusCode: 401,
-        statusMessage: 'Company users cannot post events for other companies',
-      })
-  } else if (!hasAccess(user, ['admin']))
-    throw createError({
-      statusCode: 401,
-      statusMessage: 'User not authenticated',
-    })
-
   // check if data is defined.
   if (
     !companyUID ||
@@ -43,6 +30,19 @@ export default defineEventHandler(async (event) => {
     throw createError({
       statusCode: 400,
       statusMessage: 'Not all data is defined',
+    })
+
+  // Check if user is authorized
+  if (hasAccess(user, ['company'])) {
+    if (user.companyUID !== companyUID)
+      throw createError({
+        statusCode: 401,
+        statusMessage: 'Company users cannot post events for other companies',
+      })
+  } else if (!hasAccess(user, ['admin']))
+    throw createError({
+      statusCode: 401,
+      statusMessage: 'User not authenticated',
     })
 
   // Check if capacity is legal

--- a/server/api/event/index.put.ts
+++ b/server/api/event/index.put.ts
@@ -95,5 +95,5 @@ export default defineEventHandler(async (event) => {
   // Update database information
   eventRef.update(updates)
 
-  sendNoContent(event, 203)
+  sendNoContent(event, 204)
 })

--- a/server/api/job/index.delete.ts
+++ b/server/api/job/index.delete.ts
@@ -1,0 +1,54 @@
+// DELETE /api/job
+// endpoint for removing a job from db
+
+export default defineEventHandler(async (event) => {
+  const { user } = event.context
+
+  const { jobUID } = getQuery(event)
+
+  if (!jobUID)
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Missing jobUID',
+    })
+
+  // reference to companies
+  const jobsRef = db.ref('jobs')
+
+  // check if the company exists
+  const snapshot = await jobsRef
+    .orderByKey()
+    .equalTo(jobUID as string)
+    .once('value')
+
+  const data = snapshot.val()
+
+  // the company does not exist in db
+  if (!data)
+    throw createError({
+      statusCode: 404,
+      statusMessage: 'Job not found',
+    })
+
+  const { companyUID } = data[Object.keys(data)[0]]
+
+  // Check if user is authorized
+  if (hasAccess(user, ['company'])) {
+    if (user?.companyUID !== companyUID)
+      throw createError({
+        statusCode: 401,
+        statusMessage:
+          'Company users can only remove jobs belonging to their own company',
+      })
+  } else if (!hasAccess(user, ['admin']))
+    throw createError({
+      statusCode: 401,
+      statusMessage: 'User not authorized',
+    })
+
+  // remove company
+  jobsRef.child(jobUID as string).remove()
+
+  // company successfully removed
+  sendNoContent(event, 204)
+})

--- a/server/api/job/index.delete.ts
+++ b/server/api/job/index.delete.ts
@@ -12,10 +12,10 @@ export default defineEventHandler(async (event) => {
       statusMessage: 'Missing jobUID',
     })
 
-  // reference to companies
+  // reference to jobs
   const jobsRef = db.ref('jobs')
 
-  // check if the company exists
+  // check if the job exists
   const snapshot = await jobsRef
     .orderByKey()
     .equalTo(jobUID as string)
@@ -23,7 +23,7 @@ export default defineEventHandler(async (event) => {
 
   const data = snapshot.val()
 
-  // the company does not exist in db
+  // the job does not exist in db
   if (!data)
     throw createError({
       statusCode: 404,

--- a/server/api/job/index.delete.ts
+++ b/server/api/job/index.delete.ts
@@ -32,15 +32,12 @@ export default defineEventHandler(async (event) => {
 
   const { companyUID } = data[Object.keys(data)[0]]
 
-  // Check if user is authorized
-  if (hasAccess(user, ['company'])) {
-    if (user?.companyUID !== companyUID)
-      throw createError({
-        statusCode: 401,
-        statusMessage:
-          'Company users can only remove jobs belonging to their own company',
-      })
-  } else if (!hasAccess(user, ['admin']))
+  const isAdmin = hasAccess(user, ['admin'])
+  const isCompanyAdmin =
+    hasAccess(user, ['company']) && user.companyUID === companyUID
+
+  // only admins and company admins can modify jobs
+  if (!isAdmin && !isCompanyAdmin)
     throw createError({
       statusCode: 401,
       statusMessage: 'User not authorized',

--- a/server/api/job/index.post.ts
+++ b/server/api/job/index.post.ts
@@ -6,8 +6,6 @@ export default defineEventHandler(async (event) => {
 
   const { companyUID, title, description, deadline } = await readBody(event)
 
-  console.log(companyUID, title, description, deadline)
-
   // make sure all necessary data is included
   if (!companyUID || !title || !description || !deadline)
     throw createError({

--- a/server/api/job/index.post.ts
+++ b/server/api/job/index.post.ts
@@ -13,14 +13,12 @@ export default defineEventHandler(async (event) => {
       statusMessage: 'Not all data is defined',
     })
 
-  // Check if user is authorized
-  if (hasAccess(user, ['company'])) {
-    if (user?.companyUID !== companyUID)
-      throw createError({
-        statusCode: 401,
-        statusMessage: 'Company users cannot post jobs for other companies',
-      })
-  } else if (!hasAccess(user, ['admin']))
+  const isAdmin = hasAccess(user, ['admin'])
+  const isCompanyAdmin =
+    hasAccess(user, ['company']) && user.companyUID === companyUID
+
+  // only admins and company admins can modify jobs
+  if (!isAdmin && !isCompanyAdmin)
     throw createError({
       statusCode: 401,
       statusMessage: 'User not authorized',

--- a/server/api/job/index.post.ts
+++ b/server/api/job/index.post.ts
@@ -1,0 +1,59 @@
+//  GET /api/job
+// endpoint for creating a new job in the database
+
+export default defineEventHandler(async (event) => {
+  const { user } = event.context
+
+  const { companyUID, title, description, deadline } = await readBody(event)
+
+  console.log(companyUID, title, description, deadline)
+
+  // make sure all necessary data is included
+  if (!companyUID || !title || !description || !deadline)
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Not all data is defined',
+    })
+
+  // Check if user is authorized
+  if (hasAccess(user, ['company'])) {
+    if (user?.companyUID !== companyUID)
+      throw createError({
+        statusCode: 401,
+        statusMessage: 'Company users cannot post jobs for other companies',
+      })
+  } else if (!hasAccess(user, ['admin']))
+    throw createError({
+      statusCode: 401,
+      statusMessage: 'User not authorized',
+    })
+
+  // reference to companies
+  const companiesRef = db.ref('companies')
+
+  // check if the company exists
+  const snapshot = await companiesRef
+    .orderByKey()
+    .equalTo(companyUID)
+    .once('value')
+
+  const data = snapshot.val()
+
+  // the company does not exist in db
+  if (!data)
+    throw createError({
+      statusCode: 404,
+      statusMessage: 'Company not found',
+    })
+
+  const jobsRef = db.ref('jobs')
+
+  jobsRef.push({
+    companyUID,
+    title,
+    description,
+    deadline,
+  })
+
+  sendNoContent(event, 201)
+})

--- a/server/api/job/index.post.ts
+++ b/server/api/job/index.post.ts
@@ -1,6 +1,8 @@
 //  GET /api/job
 // endpoint for creating a new job in the database
 
+import { isValidDate } from '../../../composables/useDate'
+
 export default defineEventHandler(async (event) => {
   const { user } = event.context
 
@@ -11,6 +13,12 @@ export default defineEventHandler(async (event) => {
     throw createError({
       statusCode: 400,
       statusMessage: 'Not all data is defined',
+    })
+
+  if (!isValidDate(deadline))
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Date must be of the ISO 8601 format',
     })
 
   const isAdmin = hasAccess(user, ['admin'])

--- a/server/api/job/index.put.ts
+++ b/server/api/job/index.put.ts
@@ -1,0 +1,66 @@
+// PUT /api/job
+// endpoint for editing jobs in the database
+
+export default defineEventHandler(async (event) => {
+  const { user } = event.context
+
+  const { jobUID, ...newData } = await readBody(event)
+
+  if (!jobUID)
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Missing jobUID',
+    })
+
+  // check if any of the newData values are null
+  const valuesArr = Object.values(newData)
+  if (valuesArr.includes(null))
+    throw createError({
+      statusCode: 401,
+      statusMessage: 'Cannot remove single fields from the database entry',
+    })
+
+  const jobsRef = db.ref('jobs')
+
+  // check if the job exists
+  const snapshot = await jobsRef
+    .orderByKey()
+    .equalTo(jobUID as string)
+    .once('value')
+
+  const data = snapshot.val()
+
+  // the job does not exist in db
+  if (!data)
+    throw createError({
+      statusCode: 404,
+      statusMessage: 'Job not found',
+    })
+
+  const { companyUID, ...dbData } = data[Object.keys(data)[0]]
+
+  const newKeys = Object.keys(newData)
+  const oldKeys = Object.keys(dbData)
+
+  // make sure all keys that are to be changed already exsists in the db
+  if (!newKeys.every((key) => oldKeys.includes(key)))
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Cannot add single fields to the database entry',
+    })
+
+  const isAdmin = hasAccess(user, ['admin'])
+  const isCompanyAdmin =
+    hasAccess(user, ['company']) && user.companyUID === companyUID
+
+  // only admins and company admins can modify jobs
+  if (!isAdmin && !isCompanyAdmin)
+    throw createError({
+      statusCode: 401,
+      statusMessage: 'User not authorized',
+    })
+
+  jobsRef.child(jobUID).update(newData)
+
+  sendNoContent(event, 204)
+})

--- a/server/api/job/index.put.ts
+++ b/server/api/job/index.put.ts
@@ -1,6 +1,8 @@
 // PUT /api/job
 // endpoint for editing jobs in the database
 
+import { isValidDate } from '../../../composables/useDate'
+
 export default defineEventHandler(async (event) => {
   const { user } = event.context
 
@@ -47,6 +49,12 @@ export default defineEventHandler(async (event) => {
     throw createError({
       statusCode: 400,
       statusMessage: 'Cannot add single fields to the database entry',
+    })
+
+  if (newData.deadline && !isValidDate(newData.deadline))
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Date must be of the ISO 8601 format',
     })
 
   const isAdmin = hasAccess(user, ['admin'])

--- a/server/api/job/index.ts
+++ b/server/api/job/index.ts
@@ -1,0 +1,26 @@
+// GET /api/job
+// endpoint for fetching jobs from db
+
+export default defineEventHandler(async (event) => {
+  const { jobUID } = getQuery(event)
+
+  const jobsRef = db.ref('jobs')
+
+  // return all jobs if no job is specified
+  if (!jobUID) {
+    const snapshot = await jobsRef.orderByKey().once('value')
+    const data = snapshot.val()
+
+    return data
+  }
+
+  // get specified event
+  const snapshot = await jobsRef
+    .orderByKey()
+    .equalTo(jobUID as string)
+    .once('value')
+
+  const data = snapshot.val()
+
+  return data
+})


### PR DESCRIPTION
Adds API endpoints for managing jobs in the database 🙌 
The endpoints have been tested using _Postman_.

# Changes
- `GET /api/job` fetches jobs from the database. Add `jobUID` as a query param to specify a job, otherwise all jobs will be fetched.
- `POST /api/job` creates a new job in the database. Only admins and company admins (companyUID matches that of the user) can create new jobs. The endpoint takes a body of the format
```ts
{
  companyUID: string
  title: string
  description: string
  deadline: string // iso 8601
}
```
- `PUT /api/job` modifies a job in the db. The same restrictions as the POST endpoint apply. The body accepts the same keys as the POST request, but you only need to include those that you wish to update. Setting a key value to _null_ will return an error. In addition the body accepts an extra key `jobUID` which is the job to be modified.