### PR TITLE
feat: remove user from event

### DIFF
--- a/components/program/Timeline.vue
+++ b/components/program/Timeline.vue
@@ -95,8 +95,9 @@
 
   // Sign up for event
   const signUpForEvent = (eventUID: string) => {
-    $fetch(`/api/event/register/${eventUID}`, {
+    $fetch('/api/event/register', {
       method: 'POST',
+      body: { eventUID },
     })
       .then(() => refreshEvents())
       .then(() => displaySuccessAlert('alert.success.event.register.sign_up'))
@@ -105,8 +106,9 @@
 
   // Opt out of event
   const optOutOfEvent = (eventUID: string) => {
-    $fetch(`/api/event/register/${eventUID}`, {
+    $fetch('/api/event/register', {
       method: 'DELETE',
+      body: { eventUID },
     })
       .then(() => refreshEvents())
       .then(() => displaySuccessAlert('alert.success.event.register.opt_out'))

--- a/composables/useAlerts.ts
+++ b/composables/useAlerts.ts
@@ -87,6 +87,14 @@ const errorMessageMap = new Map([
       message: 'registration_unnecessary',
     },
   ],
+  [
+    'Events: Error (register/non-admin-user).',
+    {
+      source: 'event.register',
+      type: 'error',
+      message: 'non_admin_user',
+    },
+  ],
 ])
 
 export type AlertType = 'error' | 'info' | 'success' | 'warning' | undefined

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -112,7 +112,8 @@
           "event_is_full": "Event is full",
           "already_registered": "You are already registered for this event",
           "user_not_registered": "You are not registered for this event",
-          "registration_unnecessary": "Registration is not necessary for this event"
+          "registration_unnecessary": "Registration is not necessary for this event",
+          "non_admin_user": "This requires admin privileges"
         }
       }
     },

--- a/locales/nb-NO.json
+++ b/locales/nb-NO.json
@@ -111,7 +111,8 @@
           "event_is_full": "Arrangementet er fullt",
           "already_registered": "Du er allerede påmeldt dette arrangementet",
           "user_not_registered": "Du er ikke påmeldt dette arrangementet",
-          "registration_unnecessary": "Påmelding er ikke nødvendig for dette arrangementet"
+          "registration_unnecessary": "Påmelding er ikke nødvendig for dette arrangementet",
+          "non_admin_user": "Dette krever administratorrettigheter"
         }
       }
     },

--- a/server/api/event/register/index.delete.ts
+++ b/server/api/event/register/index.delete.ts
@@ -2,7 +2,8 @@
 // endpoint for opting out of an event
 export default defineEventHandler(async (event) => {
   const { user } = event.context
-  const eventUID = getRouterParam(event, 'eventUID') as string
+
+  const { eventUID } = await readBody(event)
 
   // user is not authenticated
   if (!user) {
@@ -21,11 +22,8 @@ export default defineEventHandler(async (event) => {
   }
 
   // Get event from database
-  const attendantsRef = db.ref('events')
-  const snapshot = await attendantsRef
-    .orderByKey()
-    .equalTo(eventUID)
-    .once('value')
+  const eventsRef = db.ref('events')
+  const snapshot = await eventsRef.orderByKey().equalTo(eventUID).once('value')
   const data = snapshot.val()
 
   // Event does not exist
@@ -54,7 +52,7 @@ export default defineEventHandler(async (event) => {
   delete attendees[attendantUID]
 
   // Update attendants
-  attendantsRef.child(eventUID).child('attendants').set(attendees)
+  eventsRef.child(eventUID).child('attendants').set(attendees)
 
   // User successfully opted out of event
   sendNoContent(event, 201)


### PR DESCRIPTION
# Changes
* `event/register` API now uses eventUID param in body
* Enabling admins to register or remove other users from events. This is to support functionality provided in #146.

**NB!** Should be merged before #146.