### PR TITLE
refactor:  verbose firebase-admin auth certificate

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -20,10 +20,50 @@ export default defineNuxtConfig({
   },
   runtimeConfig: {
     // used by firebase admin sdk
-    GOOGLE_APPLICATION_CREDENTIALS:
+    FB_ADMIN_TYPE:
       process.env.NODE_ENV === 'production'
-        ? process.env.GOOGLE_APPLICATION_CREDENTIALS_PROD
-        : process.env.GOOGLE_APPLICATION_CREDENTIALS_DEV,
+        ? process.env.FB_ADMIN_TYPE_PROD
+        : process.env.FB_ADMIN_TYPE_DEV,
+    FB_ADMIN_PROJECT_ID:
+      process.env.NODE_ENV === 'production'
+        ? process.env.FB_ADMIN_PROJECT_ID_PROD
+        : process.env.FB_ADMIN_PROJECT_ID_DEV,
+    FB_ADMIN_PRIVATE_KEY_ID:
+      process.env.NODE_ENV === 'production'
+        ? process.env.FB_ADMIN_PRIVATE_KEY_ID_PROD
+        : process.env.FB_ADMIN_PRIVATE_KEY_ID_DEV,
+    FB_ADMIN_PRIVATE_KEY:
+      process.env.NODE_ENV === 'production'
+        ? process.env.FB_ADMIN_PRIVATE_KEY_PROD
+        : process.env.FB_ADMIN_PRIVATE_KEY_DEV,
+    FB_ADMIN_CLIENT_EMAIL:
+      process.env.NODE_ENV === 'production'
+        ? process.env.FB_ADMIN_CLIENT_EMAIL_PROD
+        : process.env.FB_ADMIN_CLIENT_EMAIL_DEV,
+    FB_ADMIN_CLIENT_ID:
+      process.env.NODE_ENV === 'production'
+        ? process.env.FB_ADMIN_CLIENT_ID_PROD
+        : process.env.FB_ADMIN_CLIENT_ID_DEV,
+    FB_ADMIN_AUTH_URI:
+      process.env.NODE_ENV === 'production'
+        ? process.env.FB_ADMIN_AUTH_URI_PROD
+        : process.env.FB_ADMIN_AUTH_URI_DEV,
+    FB_ADMIN_TOKEN_URI:
+      process.env.NODE_ENV === 'production'
+        ? process.env.FB_ADMIN_TOKEN_URI_PROD
+        : process.env.FB_ADMIN_TOKEN_URI_DEV,
+    FB_ADMIN_AUTH_PROVIDER_CERL_URL:
+      process.env.NODE_ENV === 'production'
+        ? process.env.FB_ADMIN_AUTH_PROVIDER_CERL_URL_PROD
+        : process.env.FB_ADMIN_AUTH_PROVIDER_CERL_URL_DEV,
+    FB_ADMIN_CLIENT_CERT_URL:
+      process.env.NODE_ENV === 'production'
+        ? process.env.FB_ADMIN_CLIENT_CERT_URL_PROD
+        : process.env.FB_ADMIN_CLIENT_CERT_URL_DEV,
+    FB_ADMIN_UNIVERSE_DOMAIN:
+      process.env.NODE_ENV === 'production'
+        ? process.env.FB_ADMIN_UNIVERSE_DOMAIN_PROD
+        : process.env.FB_ADMIN_UNIVERSE_DOMAIN_DEV,
     public: {
       FB_API_KEY:
         process.env.NODE_ENV === 'production'

--- a/server/utils/firebase.ts
+++ b/server/utils/firebase.ts
@@ -1,4 +1,11 @@
-import { initializeApp, cert, App, getApps, getApp } from 'firebase-admin/app'
+import {
+  initializeApp,
+  cert,
+  App,
+  getApps,
+  getApp,
+  ServiceAccount,
+} from 'firebase-admin/app'
 import { getAuth } from 'firebase-admin/auth'
 import { getDatabase } from 'firebase-admin/database'
 
@@ -7,7 +14,19 @@ const config = useRuntimeConfig()
 
 if (!getApps().length) {
   firebaseAdminApp = initializeApp({
-    credential: cert(JSON.parse(config.GOOGLE_APPLICATION_CREDENTIALS)),
+    credential: cert({
+      type: config.FB_ADMIN_TYPE,
+      project_id: config.FB_ADMIN_PROJECT_ID,
+      private_key_id: config.FB_ADMIN_PRIVATE_KEY_ID,
+      private_key: config.FB_ADMIN_PRIVATE_KEY,
+      client_email: config.FB_ADMIN_CLIENT_EMAIL,
+      client_id: config.FB_ADMIN_CLIENT_ID,
+      auth_uri: config.FB_ADMIN_AUTH_URI,
+      token_uri: config.FB_ADMIN_TOKEN_URI,
+      auth_provider_x509_cert_url: config.FB_ADMIN_AUTH_PROVIDER_CERL_URL,
+      client_x509_cert_url: config.FB_ADMIN_CLIENT_CERT_URL,
+      universe_domain: config.FB_ADMIN_UNIVERSE_DOMAIN,
+    } as ServiceAccount),
     databaseURL: config.public.FB_DB_URL,
   })
 } else {


### PR DESCRIPTION
## Changes
* Verbosely setting firebase-admin SDK certification details with env variables
* Prevents use of `JSON.parse()` of object in `.env`, which caused deployment error in Digital Ocean.