### PR TITLE
feat: user email in company admin

### DIFF
--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -138,7 +138,16 @@
     "admin": {
       "title": "Company Admin",
       "dietaryrestrictions": "Allergies and Restrictions",
-      "attendants": "Attendants"
+      "attendants": "Attendants",
+      "copiedemail": "Email copied!",
+      "user": {
+        "attributes": {
+          "name": "Name",
+          "studyprogramme": "Programme",
+          "currentyear": "Year",
+          "email": "Email"
+        }
+      }
     }
   },
   "alert": {

--- a/locales/nb-NO.json
+++ b/locales/nb-NO.json
@@ -139,11 +139,13 @@
       "title": "Bedriftsadministrasjon",
       "dietaryrestrictions": "Allergener og restriksjoner",
       "attendants": "Påmeldte deltakere",
+      "copiedemail": "Epost kopiert!",
       "user": {
         "attributes": {
           "name": "Navn",
           "studyprogramme": "Studieprogram",
-          "currentyear": "Årstrinn"
+          "currentyear": "År",
+          "email": "Epost"
         }
       }
     }

--- a/pages/company/admin.vue
+++ b/pages/company/admin.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
   import { dietaryFlags } from '~/config/app.config'
   const localePath = useLocalePath()
+  const { text, copy, copied } = useClipboard()
 
   definePageMeta({
     // route and all sub routes are protected
@@ -195,6 +196,9 @@
                     <th>
                       {{ $t('company.admin.user.attributes.currentyear') }}
                     </th>
+                    <th>
+                      {{ $t('company.admin.user.attributes.email') }}
+                    </th>
                     <th>{{ $t('company.admin.dietaryrestrictions') }}</th>
                   </tr>
                 </thead>
@@ -206,6 +210,26 @@
                     <td>{{ user.name }}</td>
                     <td>{{ user.studyProgram }}</td>
                     <td>{{ user.currentYear }}</td>
+                    <td>
+                      <VTooltip location="top" color="primary">
+                        <template #activator="{ props }">
+                          <VBtn
+                            v-bind="props"
+                            size="small"
+                            variant="text"
+                            icon="mdi-content-copy"
+                            color="primary"
+                            @click="copy(user.email)"
+                          />
+                        </template>
+
+                        {{
+                          copied && text === user.email
+                            ? $t('company.admin.copiedemail')
+                            : user.email
+                        }}
+                      </VTooltip>
+                    </td>
                     <td>
                       <span
                         v-if="user?.dietaryRestrictions"


### PR DESCRIPTION
## Changes
* Admin panel in `/company/admin` now allows for copying emails of attendants in order to mail them about changes in event