### PR TITLE
add default empty arrays when no events are present

### DIFF
--- a/pages/admin/events.vue
+++ b/pages/admin/events.vue
@@ -11,8 +11,8 @@
   const { text, copy, copied } = useClipboard()
 
   // Proces events and retrieve dates
-  const eventsWithID = computed(() => addEventIDAsProperty(events.value))
-  const eventDates = computed(() => getEventDates(events.value))
+  const eventsWithID = computed(() => addEventIDAsProperty(events.value ?? []))
+  const eventDates = computed(() => getEventDates(events.value ?? []))
 
   // State for filtering and selecting events
   const selectedDates = ref<number[]>(eventDates.value.map((_, i) => i))


### PR DESCRIPTION
Added empty arrays when the events tab is not able to pull any events from firebase. This fixes a crash when no events are available.