### PR TITLE
feat(server): sample successful wide events at 10%

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,8 +24,10 @@ NUXT_FIREBASE_ADMIN_UNIVERSE_DOMAIN = ""
 # Wide-event logging (server/utils/logger.ts)
 # LOG_LEVEL: debug | info | warn | error (default: debug in dev, info otherwise)
 LOG_LEVEL = ""
-# LOG_SAMPLE_RATE: 0.0-1.0 sample rate for successful requests (default: 1.0).
-# Errors, slow (>2000ms), and admin requests are always kept.
+# LOG_SAMPLE_RATE: 0.0-1.0 sample rate for successful requests
+# (default: 0.1 in production, 1.0 elsewhere). Warnings, errors, 4xx/5xx, slow
+# (>2000ms) and admin requests are always kept. Sampled events carry a
+# sample_rate field so counts can be scaled back up.
 LOG_SAMPLE_RATE = ""
 # SERVICE_NAME: service identifier in emitted events (default: et-dagen-api)
 SERVICE_NAME = ""

--- a/server/utils/logger.test.ts
+++ b/server/utils/logger.test.ts
@@ -123,6 +123,74 @@ describe('logWideEvent', () => {
     expect(out).toBeNull()
   })
 
+  it('never samples warnings, even at rate 0', () => {
+    process.env.NODE_ENV = 'production'
+    process.env.LOG_LEVEL = 'warn'
+    process.env.LOG_SAMPLE_RATE = '0'
+    const e = createWideEvent('r', 'GET', '/')
+    e.status_code = 400
+    e.outcome = 'client_error'
+    const out = emit(e, 'warn')
+    expect(out).not.toBeNull()
+    expect(out.sample_rate).toBeUndefined()
+  })
+
+  it('defaults to sampling 10% of successful requests in production', () => {
+    process.env.NODE_ENV = 'production'
+    process.env.LOG_LEVEL = 'info'
+    delete process.env.LOG_SAMPLE_RATE
+    const e = createWideEvent('r', 'GET', '/')
+    e.status_code = 200
+
+    vi.spyOn(Math, 'random').mockReturnValue(0.05)
+    expect(emit(e, 'info')?.sample_rate).toBe(0.1)
+
+    vi.spyOn(Math, 'random').mockReturnValue(0.5)
+    expect(emit(e, 'info')).toBeNull()
+  })
+
+  it('keeps every successful request when the rate is 1', () => {
+    process.env.NODE_ENV = 'production'
+    process.env.LOG_LEVEL = 'info'
+    process.env.LOG_SAMPLE_RATE = '1'
+    const e = createWideEvent('r', 'GET', '/')
+    e.status_code = 200
+    vi.spyOn(Math, 'random').mockReturnValue(0.99)
+    const out = emit(e, 'info')
+    expect(out).not.toBeNull()
+    expect(out.sample_rate).toBeUndefined()
+  })
+
+  it('falls back to the default rate when the value is unparseable', () => {
+    process.env.NODE_ENV = 'production'
+    process.env.LOG_LEVEL = 'info'
+    process.env.LOG_SAMPLE_RATE = 'not-a-number'
+    const e = createWideEvent('r', 'GET', '/')
+    e.status_code = 200
+    vi.spyOn(Math, 'random').mockReturnValue(0.05)
+    expect(emit(e, 'info')?.sample_rate).toBe(0.1)
+  })
+
+  it('keeps everything outside production when the rate is unset', () => {
+    process.env.NODE_ENV = 'test'
+    process.env.LOG_LEVEL = 'info'
+    delete process.env.LOG_SAMPLE_RATE
+    const e = createWideEvent('r', 'GET', '/')
+    e.status_code = 200
+    vi.spyOn(Math, 'random').mockReturnValue(0.99)
+    expect(emit(e, 'info')).not.toBeNull()
+  })
+
+  it('always keeps slow successful requests', () => {
+    process.env.NODE_ENV = 'production'
+    process.env.LOG_LEVEL = 'info'
+    process.env.LOG_SAMPLE_RATE = '0'
+    const e = createWideEvent('r', 'GET', '/')
+    e.status_code = 200
+    e.duration_ms = 2500
+    expect(emit(e, 'info')).not.toBeNull()
+  })
+
   it('always keeps admin requests for audit', () => {
     process.env.NODE_ENV = 'production'
     process.env.LOG_LEVEL = 'info'

--- a/server/utils/logger.ts
+++ b/server/utils/logger.ts
@@ -90,6 +90,11 @@ export interface WideEvent {
   // Outcome
   outcome: 'success' | 'error' | 'client_error'
 
+  // Fraction of comparable events kept, present only when this event survived
+  // sampling (i.e. rate < 1). Multiply counts by 1/sample_rate to reconstruct
+  // real traffic volume from sampled logs.
+  sample_rate?: number
+
   // Log importance - determines if this request should be logged based on log level
   _importance?: LogImportance
 
@@ -168,31 +173,51 @@ function shouldLog(level: LogLevel, importance?: LogImportance): boolean {
   return LOG_LEVEL_PRIORITY[level] >= LOG_LEVEL_PRIORITY[currentLevel]
 }
 
-// Tail sampling decision - always keep errors and slow requests
-function shouldSample(event: WideEvent): boolean {
-  // Always keep errors
-  if (event.outcome === 'error') return true
-  if (event.status_code && event.status_code >= 500) return true
-  if (event.error) return true
+/**
+ * Fraction of successful requests kept in production when LOG_SAMPLE_RATE is
+ * unset. Nothing that carries a warning or an error is ever sampled, so this
+ * only thins out the high-volume, uninteresting happy path.
+ */
+const DEFAULT_PRODUCTION_SAMPLE_RATE = 0.1
+
+/**
+ * Configured sample rate for successful requests.
+ *
+ * Guard against a misconfigured env var: parseFloat can yield NaN (or an
+ * out-of-range value), and `Math.random() < NaN` is always false — which would
+ * silently drop *all* successful-request logs. Fall back to the default and
+ * clamp to [0,1].
+ */
+function getConfiguredSampleRate(): number {
+  const parsed = parseFloat(getLogConfig().logSampleRate ?? '')
+  if (Number.isFinite(parsed)) return Math.min(Math.max(parsed, 0), 1)
+  return process.env.NODE_ENV === 'production'
+    ? DEFAULT_PRODUCTION_SAMPLE_RATE
+    : 1
+}
+
+/**
+ * Tail sampling decision, expressed as the probability this event is kept.
+ * A rate of 1 means "always keep" — warnings, errors, slow and admin requests
+ * are never thinned. Only successful requests are subject to the sample rate.
+ */
+function samplingRateFor(event: WideEvent, level: LogLevel): number {
+  // Never sample anything logged as a warning or an error
+  if (level === 'warn' || level === 'error') return 1
+  if (event.outcome !== 'success') return 1
+  if (event.status_code && event.status_code >= 400) return 1
+  if (event.error) return 1
 
   // Always keep slow requests (above 2000ms threshold)
-  if (event.duration_ms && event.duration_ms > 2000) return true
+  if (event.duration_ms && event.duration_ms > 2000) return 1
 
   // Always keep admin users for audit purposes
-  if (event.user?.access_level === 'admin') return true
+  if (event.user?.access_level === 'admin') return 1
 
   // In development, log everything
-  if (process.env.NODE_ENV === 'development') return true
+  if (process.env.NODE_ENV === 'development') return 1
 
-  // Sample rate for successful requests (default 100% in dev, configurable in prod).
-  // Guard against a misconfigured env var: parseFloat can yield NaN (or an
-  // out-of-range value), and `Math.random() < NaN` is always false — which would
-  // silently drop *all* successful-request logs. Fall back to 1.0 and clamp to [0,1].
-  const parsed = parseFloat(getLogConfig().logSampleRate ?? '')
-  const sampleRate = Number.isFinite(parsed)
-    ? Math.min(Math.max(parsed, 0), 1)
-    : 1
-  return Math.random() < sampleRate
+  return getConfiguredSampleRate()
 }
 
 /**
@@ -267,9 +292,13 @@ function sanitizeEvent(event: WideEvent): WideEvent {
 // Main logging function
 export function logWideEvent(event: WideEvent, level: LogLevel = 'info'): void {
   if (!shouldLog(level, event._importance)) return
-  if (!shouldSample(event)) return
+
+  const sampleRate = samplingRateFor(event, level)
+  if (sampleRate < 1 && Math.random() >= sampleRate) return
 
   const sanitized = sanitizeEvent(event)
+  if (sampleRate < 1) sanitized.sample_rate = sampleRate
+
   const logEntry = {
     level,
     ...sanitized,


### PR DESCRIPTION
Closes #536

Wide-event logs kept every request. Now only successful requests are sampled — default `LOG_SAMPLE_RATE` is 0.1 in production, 1.0 elsewhere.

- `shouldSample(event)` becomes `samplingRateFor(event, level)`, returning a keep-probability. It returns 1 (always keep) for `warn`/`error` levels, non-success outcomes, status >= 400, events carrying an error, requests over 2000ms, admin users, and development.
- Fixes a latent bug: 4xx `client_error` events are logged at `warn` but previously fell through to the sample-rate branch, so any rate below 1 could drop them.
- Kept events that passed a sampling roll carry a `sample_rate` field, so counts can be scaled back up (10 real requests per logged one at 0.1).
- `.env.example` documents the new default.

Six new cases in `server/utils/logger.test.ts` cover the level exemption, the 10% default, rate 1, unparseable values, slow requests and non-production. Full suite: 34 passed.